### PR TITLE
Rename branches: forge/fabric/neoforge/X-Y and acrhive/forge-X.Y.Z

### DIFF
--- a/tools/Resolve-BuildMatrix.ps1
+++ b/tools/Resolve-BuildMatrix.ps1
@@ -8,20 +8,20 @@ $ErrorActionPreference = 'Stop'
 
 $activeBranchGroups = [ordered]@{
     forge = @(
-        'forge-1.7.2-1.11.2',
-        'forge-1.12.2',
-        'forge-1.13.2-1.15.2',
-        'forge-1.16.4-1.18.2',
-        'forge-1.19.2-1.21.11'
+        'forge/1.7.2-1.11.2',
+        'forge/1.12.2',
+        'forge/1.13.2-1.15.2',
+        'forge/1.16.4-1.18.2',
+        'forge/1.19.2-1.21.11'
     )
     fabric = @(
-        'fabric-1.14.4-1.15.2',
-        'fabric-1.16.4-1.16.5',
-        'fabric-1.17.1-1.20.1',
-        'fabric-1.20.6-1.21.11'
+        'fabric/1.14.4-1.15.2',
+        'fabric/1.16.4-1.16.5',
+        'fabric/1.17.1-1.20.1',
+        'fabric/1.20.6-1.21.11'
     )
     neoforge = @(
-        'neoforge-1.20.1-1.21.11'
+        'neoforge/1.20.1-1.21.11'
     )
 }
 
@@ -50,7 +50,7 @@ function Get-TargetBranches {
         }
 
         foreach ($branch in $customBranches) {
-            if ($branch -like 'z-acrhive-*') {
+            if ($branch -like 'acrhive/*') {
                 throw "Archive branches are not allowed: $branch"
             }
 

--- a/tools/SharedSyncCommon.ps1
+++ b/tools/SharedSyncCommon.ps1
@@ -71,7 +71,7 @@ function Resolve-SharedBranches {
         }
 
         foreach ($branch in $customBranches) {
-            if ($branch -like 'z-acrhive-*') {
+            if ($branch -like 'acrhive/*') {
                 throw "Archive branches are not allowed: $branch"
             }
 
@@ -89,13 +89,13 @@ function Resolve-SharedBranches {
             return $availableBranches
         }
         'forge' {
-            return @($availableBranches | Where-Object { $_ -like 'forge-*' })
+            return @($availableBranches | Where-Object { $_ -like 'forge/*' })
         }
         'fabric' {
-            return @($availableBranches | Where-Object { $_ -like 'fabric-*' })
+            return @($availableBranches | Where-Object { $_ -like 'fabric/*' })
         }
         'neoforge' {
-            return @($availableBranches | Where-Object { $_ -like 'neoforge-*' })
+            return @($availableBranches | Where-Object { $_ -like 'neoforge/*' })
         }
         default {
             throw "Unsupported profile: $Profile"

--- a/tools/shared-sync-map.json
+++ b/tools/shared-sync-map.json
@@ -5,43 +5,43 @@
       "source": "shared-source/core",
       "targets": [
         {
-          "branch": "forge-1.7.2-1.11.2",
+          "branch": "forge/1.7.2-1.11.2",
           "destination": "shared/core"
         },
         {
-          "branch": "forge-1.12.2",
+          "branch": "forge/1.12.2",
           "destination": "shared/core"
         },
         {
-          "branch": "forge-1.13.2-1.15.2",
+          "branch": "forge/1.13.2-1.15.2",
           "destination": "shared/core"
         },
         {
-          "branch": "forge-1.16.4-1.18.2",
+          "branch": "forge/1.16.4-1.18.2",
           "destination": "shared/core"
         },
         {
-          "branch": "forge-1.19.2-1.21.11",
+          "branch": "forge/1.19.2-1.21.11",
           "destination": "shared/core"
         },
         {
-          "branch": "fabric-1.14.4-1.15.2",
+          "branch": "fabric/1.14.4-1.15.2",
           "destination": "shared/core"
         },
         {
-          "branch": "fabric-1.16.4-1.16.5",
+          "branch": "fabric/1.16.4-1.16.5",
           "destination": "shared/core"
         },
         {
-          "branch": "fabric-1.17.1-1.20.1",
+          "branch": "fabric/1.17.1-1.20.1",
           "destination": "shared/core"
         },
         {
-          "branch": "fabric-1.20.6-1.21.11",
+          "branch": "fabric/1.20.6-1.21.11",
           "destination": "shared/core"
         },
         {
-          "branch": "neoforge-1.20.1-1.21.11",
+          "branch": "neoforge/1.20.1-1.21.11",
           "destination": "shared/core"
         }
       ]
@@ -51,7 +51,7 @@
       "source": "shared-source/lang/legacy",
       "targets": [
         {
-          "branch": "forge-1.7.2-1.11.2",
+          "branch": "forge/1.7.2-1.11.2",
           "versions": ["1.7.2", "1.7.10", "1.8", "1.8.9", "1.9.4", "1.10.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang",
           "renames": [
@@ -62,12 +62,12 @@
           ]
         },
         {
-          "branch": "forge-1.7.2-1.11.2",
+          "branch": "forge/1.7.2-1.11.2",
           "versions": ["1.11.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "forge-1.12.2",
+          "branch": "forge/1.12.2",
           "versions": ["1.12.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         }
@@ -78,42 +78,42 @@
       "source": "shared-source/lang/json",
       "targets": [
         {
-          "branch": "forge-1.13.2-1.15.2",
+          "branch": "forge/1.13.2-1.15.2",
           "versions": ["1.13.2", "1.14.2", "1.14.4", "1.15.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "forge-1.16.4-1.18.2",
+          "branch": "forge/1.16.4-1.18.2",
           "versions": ["1.16.4", "1.16.5", "1.17.1", "1.18.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "forge-1.19.2-1.21.11",
+          "branch": "forge/1.19.2-1.21.11",
           "versions": ["1.19.2", "1.19.4", "1.20.1", "1.20.6", "1.21.1", "1.21.5", "1.21.11"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "fabric-1.14.4-1.15.2",
+          "branch": "fabric/1.14.4-1.15.2",
           "versions": ["1.14.4", "1.15.2"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "fabric-1.16.4-1.16.5",
+          "branch": "fabric/1.16.4-1.16.5",
           "versions": ["1.16.4", "1.16.5"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "fabric-1.17.1-1.20.1",
+          "branch": "fabric/1.17.1-1.20.1",
           "versions": ["1.17.1", "1.18.2", "1.19.2", "1.19.4", "1.20.1"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "fabric-1.20.6-1.21.11",
+          "branch": "fabric/1.20.6-1.21.11",
           "versions": ["1.20.6", "1.21.1", "1.21.5", "1.21.11"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         },
         {
-          "branch": "neoforge-1.20.1-1.21.11",
+          "branch": "neoforge/1.20.1-1.21.11",
           "versions": ["1.20.1", "1.20.6", "1.21.1", "1.21.5", "1.21.11"],
           "destinationTemplate": "versions/{{version}}/project/src/main/resources/assets/easylan/lang"
         }


### PR DESCRIPTION
## Summary

Rename branches to a cleaner, namespaced convention and update every reference in `tools/` so the sync + aggregate-build workflows keep working.

**Branch rename plan** (executed via the GitHub branch-rename API after this PR is opened, so PRs / refs / web redirects are preserved):

Active branches (`-` after loader → `/`):
- `forge-1.7.2-1.11.2` → `forge/1.7.2-1.11.2`
- `forge-1.12.2` → `forge/1.12.2`
- `forge-1.13.2-1.15.2` → `forge/1.13.2-1.15.2`
- `forge-1.16.4-1.18.2` → `forge/1.16.4-1.18.2`
- `forge-1.19.2-1.21.11` → `forge/1.19.2-1.21.11`
- `fabric-1.14.4-1.15.2` → `fabric/1.14.4-1.15.2`
- `fabric-1.16.4-1.16.5` → `fabric/1.16.4-1.16.5`
- `fabric-1.17.1-1.20.1` → `fabric/1.17.1-1.20.1`
- `fabric-1.20.6-1.21.11` → `fabric/1.20.6-1.21.11`
- `neoforge-1.20.1-1.21.11` → `neoforge/1.20.1-1.21.11`

Archive branches (`z-acrhive-X.Y.Z` → `acrhive/forge-X.Y.Z`, all confirmed Forge by checking `build.gradle`):
- `z-acrhive-1.7.2`, `z-acrhive-1.7.10`, `z-acrhive-1.8`, `z-acrhive-1.8.9`, `z-acrhive-1.9.4`, `z-acrhive-1.10.2`, `z-acrhive-1.11.2`, `z-acrhive-1.12.2`, `z-acrhive-1.14.2`, `z-acrhive-1.14.4`, `z-acrhive-1.15.2`, `z-acrhive-1.16.4`, `z-acrhive-1.16.5`, `z-acrhive-1.17.1`, `z-acrhive-1.18.2`, `z-acrhive-1.19.2`, `z-acrhive-1.19.4`, `z-acrhive-1.20.1`, `z-acrhive-1.20.6`, `z-acrhive-1.21.1` → corresponding `acrhive/forge-*`

**Code changes in this PR**:
- `tools/shared-sync-map.json`: 21 target branch names updated.
- `tools/Resolve-BuildMatrix.ps1`: hardcoded forge/fabric/neoforge active branch lists updated; archive guard `'z-acrhive-*'` → `'acrhive/*'`.
- `tools/SharedSyncCommon.ps1`: profile filters `'forge-*' / 'fabric-*' / 'neoforge-*'` → `'forge/*' / 'fabric/*' / 'neoforge/*'`; archive guard updated.

**Sequencing** (important):
1. PR opened against `main` (this PR) — does NOT trigger the sync workflow yet (only push to `main` does).
2. The 30 branch renames will be performed via the GitHub API right after this PR is opened.
3. After you merge this PR, `Sync Shared Source` will run on `main` push and use the new branch names.

If the order is wrong (renames happen *after* merge), the sync workflow will fail on the first run because it would try to clone the old branch names. Renaming first avoids that.

## Review & Testing Checklist for Human

- [ ] Confirm the new naming convention is what you actually want (especially the `acrhive/forge-*` archive prefix — the misspelling "acrhive" is preserved from your existing branches; flag if you'd rather fix it to `archive/`).
- [ ] After merging, verify a `Sync Shared Source` run on `main` (e.g. trivially edit `shared-source/...` or just dispatch the workflow manually) lists the new branch names and pushes successfully to all of them.
- [ ] Dispatch `Aggregate Build` (profile `all`) and confirm the matrix contains the new branch names and the build still succeeds.
- [ ] Spot-check that `https://github.com/xiaoxianhw/easylan/tree/forge-1.19.2-1.21.11` still redirects (GitHub keeps redirects after API renames). Same for archive branches.
- [ ] If you have any external tooling, bookmarks, or docs referencing the old branch names, update them.

### Notes
- Confirmed all 20 `z-acrhive-*` branches are Forge (checked `build.gradle` for ForgeGradle/`apply plugin: 'net.minecraftforge.gradle'`).
- No branches are protected and no open PRs exist on the repo, so the rename is safe.
- README and workflow YAMLs do not hardcode any branch names that need updating.