### PR TITLE
ci: sanitize artifact names to remove forward slashes

### DIFF
--- a/.github/workflows/aggregate-build.yml
+++ b/.github/workflows/aggregate-build.yml
@@ -116,10 +116,20 @@ jobs:
           chmod +x ./gradlew
           ./gradlew build
 
+      - name: Resolve artifact name
+        id: artifact-name
+        shell: bash
+        env:
+          BRANCH: ${{ matrix.branch }}
+          VERSION: ${{ matrix.version }}
+        run: |
+          safe_branch="${BRANCH//\//-}"
+          echo "name=easylan-${safe_branch}-${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Upload ${{ matrix.branch }} / ${{ matrix.version }}
         uses: actions/upload-artifact@v4
         with:
-          name: easylan-${{ matrix.branch }}-${{ matrix.version }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: |
             versions/${{ matrix.version }}/project/build/libs/*.jar
             !versions/${{ matrix.version }}/project/build/libs/*-sources.jar


### PR DESCRIPTION
Fixes the GitHub Actions workflow artifact upload failure caused by branch names containing forward slashes (e.g. `fabric/1.14.4-1.15.2`).

The artifact name `easylan-${{ matrix.branch }}-${{ matrix.version }}` resolved to `easylan-fabric/1.14.4-1.15.2-1.15.2`, which is rejected by `actions/upload-artifact@v4` because `/` is not a valid character in artifact names.

## Change
Added a `Resolve artifact name` step before `Upload` that computes a sanitized artifact name by replacing `/` with `-` via bash parameter expansion (`${BRANCH//\//-}`). The upload step now uses the step output, e.g. `easylan-fabric-1.14.4-1.15.2-1.15.2`.